### PR TITLE
盤面のデータ型を整理する

### DIFF
--- a/src/features/PlayGround/hooks/usePlayGround.ts
+++ b/src/features/PlayGround/hooks/usePlayGround.ts
@@ -4,7 +4,7 @@ import useBoard, { Board, BoardConfig } from './useBoard';
 type GameState = 'playing' | 'win' | 'lose';
 
 const isWin = (board: Board): boolean => {
-  return board.flat().every((cell) => {
+  return board.data.flat().every((cell) => {
     return cell.isMine || cell.isOpen; // 爆弾以外のマスが全て開いていたら勝利
   });
 };
@@ -62,13 +62,9 @@ const usePlayGround = () => {
     }
   };
 
-  const getConfig = () => {
-    return gameModeToOptions(mode);
-  };
+  const countFlags = () => board.data.flat().filter((cell) => cell.isFlagged).length;
 
-  const countFlags = () => board.flat().filter((cell) => cell.isFlagged).length;
-
-  return { board, gameState, init, reset, open, getConfig, toggleFlag, countFlags, mode };
+  return { board, gameState, init, reset, open, toggleFlag, countFlags, mode };
 };
 
 export default usePlayGround;

--- a/src/features/PlayGround/index.tsx
+++ b/src/features/PlayGround/index.tsx
@@ -13,8 +13,7 @@ import Image from 'next/image';
 // TODO: 難易度選択
 
 const PlayGround = () => {
-  const { board, gameState, reset, init, open, getConfig, countFlags, toggleFlag, mode } =
-    usePlayGround();
+  const { board, gameState, reset, init, open, countFlags, toggleFlag, mode } = usePlayGround();
   const confetti = useConfetti();
   const boardRef = useRef<HTMLDivElement>(null);
 
@@ -59,7 +58,7 @@ const PlayGround = () => {
           </div>
           <div className='flex items-center'>
             <Image src='/mine.svg' alt='exploded mine' width={15} height={15} />
-            <span className='text-xs'>×{getConfig().mines}</span>
+            <span className='text-xs'>×{board.meta.mines}</span>
           </div>
         </div>
       </header>
@@ -72,11 +71,11 @@ const PlayGround = () => {
         <div
           className={'bg-slate-700 grid gap-1 p-2 w-fit'}
           style={{
-            gridTemplateColumns: `repeat(${board[0].length}, 1fr)`,
-            gridTemplateRows: `repeat(${board.length}, 1fr)`,
+            gridTemplateColumns: `repeat(${board.meta.cols}, 1fr)`,
+            gridTemplateRows: `repeat(${board.meta.rows}, 1fr)`,
           }}
         >
-          {board.flat().map((cell) => {
+          {board.data.flat().map((cell) => {
             return (
               <Cell
                 key={cell.id}


### PR DESCRIPTION
背景
* 盤面の設定(サイズや爆弾の数)と実際のデータの置き場所が乖離し、コードが複雑化したり整合性が取りにくくなったりしていた
* 今後パフォーマンス最適化に向けてデータとロジックを扱いやすいようにリファクタしたい

やったこと
* 盤面の設定と実際の盤面のデータを一つの型として扱えるようにした
* 最初のクリックで始めて盤面の状態が確定する都合で、苦肉の策としてinitializedプロパティを追加した