### PR TITLE
Optimize cell rendering

### DIFF
--- a/src/features/PlayGround/components/Cell/index.tsx
+++ b/src/features/PlayGround/components/Cell/index.tsx
@@ -4,15 +4,17 @@ import React from 'react';
 import OpenedCell from './OpenedCell';
 import UnopenedCell from './UnopenedCell';
 import { CellData } from '../../functions/board';
+import { Action } from '../../hooks/usePlayGround';
 
 type Props = {
   cell: CellData;
-  handleClick: (id: number) => void;
+  dispatch: React.Dispatch<Action>;
   isFailed: boolean;
-  toggleFlag: (id: number) => void;
 };
 
-const Cell: React.FC<Props> = ({ cell, handleClick, isFailed = false, toggleFlag }) => {
+const Cell: React.FC<Props> = ({ cell, dispatch, isFailed = false }) => {
+  const handleClick = () => dispatch({ type: 'open', index: cell.id });
+  const toggleFlag = () => dispatch({ type: 'toggleFlag', index: cell.id });
   return (
     <div className={'flex justify-center items-center aspect-square w-[8vmin] md:w-[6vmin]'}>
       {cell.isOpen ? (
@@ -24,4 +26,4 @@ const Cell: React.FC<Props> = ({ cell, handleClick, isFailed = false, toggleFlag
   );
 };
 
-export default Cell;
+export default React.memo(Cell);

--- a/src/features/PlayGround/components/Cell/index.tsx
+++ b/src/features/PlayGround/components/Cell/index.tsx
@@ -4,23 +4,25 @@ import React from 'react';
 import OpenedCell from './OpenedCell';
 import UnopenedCell from './UnopenedCell';
 import { CellData } from '../../functions/board';
-import { Action } from '../../hooks/usePlayGround';
 
 type Props = {
   cell: CellData;
-  dispatch: React.Dispatch<Action>;
   isFailed: boolean;
+  handleClick: (index: number) => void;
+  toggleFlag: (index: number) => void;
 };
 
-const Cell: React.FC<Props> = ({ cell, dispatch, isFailed = false }) => {
-  const handleClick = () => dispatch({ type: 'open', index: cell.id });
-  const toggleFlag = () => dispatch({ type: 'toggleFlag', index: cell.id });
+const Cell: React.FC<Props> = ({ cell, isFailed = false, handleClick, toggleFlag }) => {
   return (
     <div className={'flex justify-center items-center aspect-square w-[8vmin] md:w-[6vmin]'}>
       {cell.isOpen ? (
         <OpenedCell cell={cell} isExploded={isFailed} />
       ) : (
-        <UnopenedCell cell={cell} handleClick={handleClick} toggleFlag={toggleFlag} />
+        <UnopenedCell
+          cell={cell}
+          handleClick={() => handleClick(cell.id)}
+          toggleFlag={() => toggleFlag(cell.id)}
+        />
       )}
     </div>
   );

--- a/src/features/PlayGround/hooks/usePlayGround.ts
+++ b/src/features/PlayGround/hooks/usePlayGround.ts
@@ -31,7 +31,7 @@ type State = {
   board: Board;
 };
 
-type Action =
+export type Action =
   | { type: 'init'; gameMode: GameMode }
   | { type: 'reset' }
   | { type: 'open'; index: number }

--- a/src/features/PlayGround/hooks/usePlayGround.ts
+++ b/src/features/PlayGround/hooks/usePlayGround.ts
@@ -31,7 +31,7 @@ type State = {
   board: Board;
 };
 
-export type Action =
+type Action =
   | { type: 'init'; gameMode: GameMode }
   | { type: 'reset' }
   | { type: 'open'; index: number }

--- a/src/features/PlayGround/index.tsx
+++ b/src/features/PlayGround/index.tsx
@@ -80,12 +80,9 @@ const PlayGround = () => {
               <Cell
                 key={cell.id}
                 cell={cell}
-                handleClick={() => dispatch({ type: 'open', index: cell.id })}
+                dispatch={dispatch}
                 isFailed={gameState === 'failed'}
-                toggleFlag={() => {
-                  dispatch({ type: 'toggleFlag', index: cell.id });
-                }}
-              ></Cell>
+              />
             );
           })}
         </div>

--- a/src/features/PlayGround/index.tsx
+++ b/src/features/PlayGround/index.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useEffect, useRef } from 'react';
+import { useCallback, useEffect, useRef } from 'react';
 import Cell from './components/Cell';
 import useConfetti from '@/hooks/useConfetti';
 import usePlayGround, { GameMode } from './hooks/usePlayGround';
@@ -47,6 +47,12 @@ const PlayGround = () => {
     }
   }, [gameMode]);
 
+  const handleClick = useCallback((index: number) => dispatch({ type: 'open', index }), [dispatch]);
+  const toggleFlag = useCallback(
+    (index: number) => dispatch({ type: 'toggleFlag', index }),
+    [dispatch],
+  );
+
   return (
     <div>
       <header className='flex justify-between items-center py-0.5'>
@@ -80,8 +86,9 @@ const PlayGround = () => {
               <Cell
                 key={cell.id}
                 cell={cell}
-                dispatch={dispatch}
                 isFailed={gameState === 'failed'}
+                handleClick={handleClick}
+                toggleFlag={toggleFlag}
               />
             );
           })}


### PR DESCRIPTION
背景：
- stateが少しでも変更されるたびにすべてのセルが再描画されていた
- 更新関数が状態に依存していたため

やったこと：
- Cellをメモ化
- 純粋関数であるdispatchを更新関数ベースにした
- 更新関数の定義は親コンポーネント(PlayGround)で行った
  - dispatch + useCallbackで更新関数をメモ
  - usePlayGroundの内部で使用しているreducerの知識が漏れ出す範囲を最小限にするため

参考リンク：
- https://sagantaf.hatenablog.com/entry/2021/11/13/192110
- https://qiita.com/uhyo/items/cea1bd157453a85feebf#fnref1
