### PR TITLE
セルのButton化とアクセシビリティの改善

### DIFF
--- a/src/features/PlayGround/components/Cell/UnopenedCell.tsx
+++ b/src/features/PlayGround/components/Cell/UnopenedCell.tsx
@@ -26,15 +26,17 @@ const UnopenedCell: React.FC<Props> = ({ handleClick, cell, toggleFlag, switchFl
     isFlagged(cell) ? switchFlagType(cell.id) : handleClick(cell.id); // フラグが立っているときは開放しない
   const longPressEvent = useLongPress(handleLongPress, handleClickWithFlag);
   // 右クリックでフラグを切り替える
-  const handleContextMenu = (e: React.MouseEvent<HTMLDivElement, MouseEvent>) => {
+  const handleContextMenu = (e: React.MouseEvent<HTMLButtonElement, MouseEvent>) => {
     e.preventDefault();
     toggleFlag(cell.id);
   };
   return (
-    <div
+    <button
+      type='button'
       className='h-full w-full flex justify-center items-center bg-slate-500 shadow-[2px_2px_2px_#444,-1px_-1px_1px_#fff]'
       {...longPressEvent}
       onContextMenu={handleContextMenu}
+      aria-label={`Cell at position ${cell.id}`}
     >
       {isFlagged(cell) &&
         (cell.state.flag === 'suspected' ? (
@@ -48,7 +50,7 @@ const UnopenedCell: React.FC<Props> = ({ handleClick, cell, toggleFlag, switchFl
             className={'w-3/5 lg:animate-none animate-slide-in-blurred-top pointer-events-none'}
           />
         ))}
-    </div>
+    </button>
   );
 };
 

--- a/src/features/PlayGround/components/Cell/UnopenedCell.tsx
+++ b/src/features/PlayGround/components/Cell/UnopenedCell.tsx
@@ -30,12 +30,24 @@ const UnopenedCell: React.FC<Props> = ({ handleClick, cell, toggleFlag, switchFl
     e.preventDefault();
     toggleFlag(cell.id);
   };
+
+  // キーボード操作
+  const handleKeyDown = (e: React.KeyboardEvent<HTMLButtonElement>) => {
+    if (e.key === 'Enter') {
+      e.preventDefault();
+      handleClickWithFlag();
+    } else if (e.key === 'f' || e.key === 'F') {
+      toggleFlag(cell.id);
+    }
+  };
+
   return (
     <button
       type='button'
       className='h-full w-full flex justify-center items-center bg-slate-500 shadow-[2px_2px_2px_#444,-1px_-1px_1px_#fff] focus:bg-slate-400'
       {...longPressEvent}
       onContextMenu={handleContextMenu}
+      onKeyDown={handleKeyDown}
       aria-label={`Cell at position ${cell.id}`}
     >
       {isFlagged(cell) &&

--- a/src/features/PlayGround/components/Cell/UnopenedCell.tsx
+++ b/src/features/PlayGround/components/Cell/UnopenedCell.tsx
@@ -33,7 +33,7 @@ const UnopenedCell: React.FC<Props> = ({ handleClick, cell, toggleFlag, switchFl
   return (
     <button
       type='button'
-      className='h-full w-full flex justify-center items-center bg-slate-500 shadow-[2px_2px_2px_#444,-1px_-1px_1px_#fff]'
+      className='h-full w-full flex justify-center items-center bg-slate-500 shadow-[2px_2px_2px_#444,-1px_-1px_1px_#fff] focus:bg-slate-400'
       {...longPressEvent}
       onContextMenu={handleContextMenu}
       aria-label={`Cell at position ${cell.id}`}

--- a/src/features/PlayGround/components/Cell/UnopenedCell.tsx
+++ b/src/features/PlayGround/components/Cell/UnopenedCell.tsx
@@ -33,7 +33,7 @@ const UnopenedCell: React.FC<Props> = ({ handleClick, cell, toggleFlag, switchFl
 
   // キーボード操作
   const handleKeyDown = (e: React.KeyboardEvent<HTMLButtonElement>) => {
-    if (e.key === 'Enter') {
+    if (e.key === 'Enter' || e.key === ' ') {
       e.preventDefault();
       handleClickWithFlag();
     } else if (e.key === 'f' || e.key === 'F') {

--- a/src/features/PlayGround/components/Cell/index.tsx
+++ b/src/features/PlayGround/components/Cell/index.tsx
@@ -1,27 +1,99 @@
 'use client';
 
-import React from 'react';
+import React, { useRef } from 'react';
 import OpenedCell from './OpenedCell';
 import UnopenedCell from './UnopenedCell';
 import { CellData, isOpened } from '../../functions/board';
 
 type Props = {
   cell: CellData;
+  row: number;
+  col: number;
   isFailed: boolean;
   handleClick: (index: number) => void;
   toggleFlag: (index: number) => void;
   switchFlagType: (id: number) => void;
 };
 
+type Direction = 'up' | 'down' | 'left' | 'right';
+
+const getClosestButton = (from: HTMLDivElement, direction: Direction): HTMLButtonElement | null => {
+  const nextElement = getNextCell(from, direction);
+  // 枠外に到達し、次のセルがない場合はnullを返す
+  if (!nextElement) return null;
+  // 子要素にボタンがある場合はそれを返す
+  const button = nextElement.querySelector('button');
+  if (button) return button;
+  // なかった場合は枠外に到達するまで再帰的に探す
+  return getClosestButton(nextElement, direction);
+};
+
+const getNextCell = (from: HTMLDivElement, direction: Direction): HTMLDivElement | null => {
+  const row = Number(from.dataset.row);
+  const col = Number(from.dataset.col);
+  switch (direction) {
+    case 'up':
+      return getCell(row - 1, col);
+    case 'down':
+      return getCell(row + 1, col);
+    case 'left':
+      return getCell(row, col - 1);
+    case 'right':
+      return getCell(row, col + 1);
+  }
+};
+
+// 上下左右のセルを取得するための関数
+const getCell = (row: number, col: number): HTMLDivElement | null => {
+  return document.querySelector(`div[data-row="${row}"][data-col="${col}"]`);
+};
+
 const Cell: React.FC<Props> = ({
   cell,
+  row,
+  col,
   isFailed = false,
   handleClick,
   toggleFlag,
   switchFlagType,
 }) => {
+  const cellRef = useRef<HTMLDivElement>(null);
+
+  // TODO: 直線方向にボタンがないときに斜め方向も探索するようにする
+  // TODO: マスを開放したあとにフォーカスが消えてしまうため、開放したマス付近にフォーカスを当て直す
+  const handleArrowMove = (e: React.KeyboardEvent<HTMLDivElement>) => {
+    const currentCell = cellRef.current;
+    if (!currentCell) return;
+
+    let closestButton: HTMLButtonElement | null;
+    switch (e.key) {
+      case 'ArrowUp':
+        closestButton = getClosestButton(currentCell, 'up');
+        break;
+      case 'ArrowDown':
+        closestButton = getClosestButton(currentCell, 'down');
+        break;
+      case 'ArrowLeft':
+        closestButton = getClosestButton(currentCell, 'left');
+        break;
+      case 'ArrowRight':
+        closestButton = getClosestButton(currentCell, 'right');
+        break;
+      default:
+        return;
+    }
+
+    closestButton?.focus();
+  };
+
   return (
-    <div className={'flex justify-center items-center aspect-square w-[8vmin] md:w-[6vmin]'}>
+    <div
+      className={'flex justify-center items-center aspect-square w-[8vmin] md:w-[6vmin]'}
+      data-row={row}
+      data-col={col}
+      ref={cellRef}
+      onKeyDown={handleArrowMove}
+    >
       {isOpened(cell) ? (
         <OpenedCell cell={cell} isExploded={isFailed} />
       ) : (

--- a/src/features/PlayGround/index.tsx
+++ b/src/features/PlayGround/index.tsx
@@ -83,7 +83,7 @@ const PlayGround = () => {
       </div>
       <div className='py-2'>
         <select
-          className='bg-slate-500 p-1 rounded-none text-sm'
+          className='bg-slate-500 p-1 rounded-none text-sm text-slate-100 focus:bg-slate-400 focus:scale-110 origin-left'
           onChange={(e) => {
             dispatch({ type: 'init', gameMode: e.target.value as GameMode });
           }}
@@ -103,7 +103,7 @@ const PlayGround = () => {
       {(gameState === 'completed' || gameState === 'failed') && (
         <div className='flex flex-col items-center py-10 gap-3'>
           <button
-            className='bg-slate-500 shadow-[2px_2px_2px_#444,-1px_-1px_1px_#fff] text-white px-3 py-1 text-sm'
+            className='bg-slate-500 shadow-[2px_2px_2px_#444,-1px_-1px_1px_#fff] text-white px-3 py-1 text-sm focus:bg-slate-400 focus:scale-110 origin-center'
             onClick={() => {
               dispatch({ type: 'reset' });
             }}

--- a/src/features/PlayGround/index.tsx
+++ b/src/features/PlayGround/index.tsx
@@ -5,6 +5,7 @@ import Cell from './components/Cell';
 import useConfetti from '@/hooks/useConfetti';
 import usePlayGround, { GameMode } from './hooks/usePlayGround';
 import { Header } from './components/Header';
+import { toMarixPosition } from './functions/matrix';
 
 const PlayGround = () => {
   const { board, gameState, gameMode, dispatch, normalFlags, suspectedflags } = usePlayGround();
@@ -68,10 +69,13 @@ const PlayGround = () => {
           }}
         >
           {board.data.flat().map((cell) => {
+            const [row, col] = toMarixPosition(cell.id, board.meta.cols);
             return (
               <Cell
                 key={cell.id}
                 cell={cell}
+                row={row}
+                col={col}
                 isFailed={gameState === 'failed'}
                 handleClick={handleClick}
                 toggleFlag={toggleFlag}


### PR DESCRIPTION
## やったこと
- 開放可能なセルにはbuttonタグを使用
- セルや難易度セレクタ等のフォーカス時に色やサイズが変わるようにした
- コントラストが上がるように難易度セレクタの文字色を変更
- キーボード操作によるプレイに対応
  - 開放：Enter, Space
  - フラグ：F
  - 移動：矢印キー
- マスの開放時には並び順(ElementのIndex)が次のセルがフォーカスされるようにした

## やっていないこと
- マスの開放時にフォーカスが消えることへの対処
  - 再度Tabを押さなければいけない
- 直線上に開放可能なセルがないと移動できない
  - TabやTab + Shiftで移動する必要がある

いずれもTabキーで回避できるためクリティカルではないが、少々不便なので要改善