### PR TITLE
レイアウトのリファクタを行いファーストビューに要素がすべて収まるようにする

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -31,11 +31,11 @@ const ps2p = Press_Start_2P({ weight: '400', preload: false });
 
 export default function RootLayout({ children }: { children: React.ReactNode }) {
   return (
-    <html lang='ja'>
+    <html lang='ja' style={{height: '-webkit-fill-available'}}>
       <head>
-        <meta name="thumbnail" content={url + '/thumbnail.png'} />
+        <meta name='thumbnail' content={url + '/thumbnail.png'} />
       </head>
-      <body className={ps2p.className}>{children}</body>
+      <body className={ps2p.className + ' h-screen w-screen'} style={{height: '-webkit-fill-available'}}>{children}</body>
       <Analytics />
     </html>
   );

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -31,11 +31,16 @@ const ps2p = Press_Start_2P({ weight: '400', preload: false });
 
 export default function RootLayout({ children }: { children: React.ReactNode }) {
   return (
-    <html lang='ja' style={{height: '-webkit-fill-available'}}>
+    <html lang='ja' style={{ height: '-webkit-fill-available' }}>
       <head>
         <meta name='thumbnail' content={url + '/thumbnail.png'} />
       </head>
-      <body className={ps2p.className + ' h-screen w-screen'} style={{height: '-webkit-fill-available'}}>{children}</body>
+      <body
+        className={ps2p.className + ' h-screen w-screen'}
+        style={{ height: '-webkit-fill-available' }}
+      >
+        {children}
+      </body>
       <Analytics />
     </html>
   );

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -2,7 +2,7 @@ import PlayGround from '@/features/PlayGround';
 
 export default function Home() {
   return (
-    <main className='flex h-full w-full flex-col items-center justify-between py-[10vh]'>
+    <main className='flex h-full w-full flex-col items-center'>
       <PlayGround></PlayGround>
     </main>
   );

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -2,7 +2,7 @@ import PlayGround from '@/features/PlayGround';
 
 export default function Home() {
   return (
-    <main className='flex h-screen w-screen flex-col items-center justify-between py-[10vh]'>
+    <main className='flex h-full w-full flex-col items-center justify-between py-[10vh]'>
       <PlayGround></PlayGround>
     </main>
   );

--- a/src/features/PlayGround/components/Board/index.tsx
+++ b/src/features/PlayGround/components/Board/index.tsx
@@ -8,7 +8,7 @@ type Props = Pick<MineSweeper, 'board' | 'open' | 'toggleFlag' | 'switchFlagType
 
 const Board: React.FC<Props> = ({ board, open, toggleFlag, switchFlagType }) => {
   return (
-    <div
+    <section
       className={'w-fit h-fit bg-slate-700 grid gap-1 p-2'}
       style={{
         gridTemplateColumns: `repeat(${board.meta.cols}, 1fr)`,
@@ -29,7 +29,7 @@ const Board: React.FC<Props> = ({ board, open, toggleFlag, switchFlagType }) => 
           />
         );
       })}
-    </div>
+    </section>
   );
 };
 

--- a/src/features/PlayGround/components/Board/index.tsx
+++ b/src/features/PlayGround/components/Board/index.tsx
@@ -9,7 +9,7 @@ type Props = Pick<MineSweeper, 'board' | 'open' | 'toggleFlag' | 'switchFlagType
 const Board: React.FC<Props> = ({ board, open, toggleFlag, switchFlagType }) => {
   return (
     <div
-      className={'bg-slate-700 grid gap-1 p-2 w-fit'}
+      className={'w-fit h-fit bg-slate-700 grid gap-1 p-2'}
       style={{
         gridTemplateColumns: `repeat(${board.meta.cols}, 1fr)`,
         gridTemplateRows: `repeat(${board.meta.rows}, 1fr)`,

--- a/src/features/PlayGround/components/Board/index.tsx
+++ b/src/features/PlayGround/components/Board/index.tsx
@@ -1,0 +1,36 @@
+'use client';
+
+import { toMarixPosition } from '../../functions/matrix';
+import Cell from '../Cell';
+import { MineSweeper } from '../../hooks/useMineSweeper';
+
+type Props = Pick<MineSweeper, 'board' | 'open' | 'toggleFlag' | 'switchFlagType'>;
+
+const Board: React.FC<Props> = ({ board, open, toggleFlag, switchFlagType }) => {
+  return (
+    <div
+      className={'bg-slate-700 grid gap-1 p-2 w-fit'}
+      style={{
+        gridTemplateColumns: `repeat(${board.meta.cols}, 1fr)`,
+        gridTemplateRows: `repeat(${board.meta.rows}, 1fr)`,
+      }}
+    >
+      {board.data.flat().map((cell) => {
+        const [row, col] = toMarixPosition(cell.id, board.meta.cols);
+        return (
+          <Cell
+            key={cell.id}
+            cell={cell}
+            row={row}
+            col={col}
+            handleClick={open}
+            toggleFlag={toggleFlag}
+            switchFlagType={switchFlagType}
+          />
+        );
+      })}
+    </div>
+  );
+};
+
+export default Board;

--- a/src/features/PlayGround/components/GameContextAction/index.tsx
+++ b/src/features/PlayGround/components/GameContextAction/index.tsx
@@ -1,0 +1,20 @@
+'use client';
+
+import type { MineSweeper } from '@/features/PlayGround/hooks/useMineSweeper';
+
+type Props = Pick<MineSweeper, 'restart'>;
+
+export const GameContextAction: React.FC<Props> = ({ restart }) => {
+  return (
+    <div className='flex flex-col items-center'>
+      <button
+        className='bg-slate-500 shadow-[1px_1px_1px_#444,-1px_-1px_1px_#fff] text-white px-4 py-2 text-sm focus:bg-slate-400 focus:scale-110 origin-center'
+        onClick={restart}
+      >
+        NEW GAME
+      </button>
+    </div>
+  );
+};
+
+export default GameContextAction;

--- a/src/features/PlayGround/components/GameContextAction/index.tsx
+++ b/src/features/PlayGround/components/GameContextAction/index.tsx
@@ -8,7 +8,7 @@ export const GameContextAction: React.FC<Props> = ({ restart }) => {
   return (
     <div className='flex flex-col items-center'>
       <button
-        className='bg-slate-500 shadow-[1px_1px_1px_#444,-1px_-1px_1px_#fff] text-white px-4 py-2 text-sm focus:bg-slate-400 focus:scale-110 origin-center'
+        className='bg-slate-500 shadow-[1px_1px_1px_#444,-1px_-1px_1px_#fff] text-white px-3 py-1 text-sm focus:bg-slate-400 focus:scale-110 origin-center'
         onClick={restart}
       >
         NEW GAME

--- a/src/features/PlayGround/components/GameInfoHeader/index.tsx
+++ b/src/features/PlayGround/components/GameInfoHeader/index.tsx
@@ -10,7 +10,7 @@ type Props = {
   boardConfig: BoardConfig;
 };
 
-export const Header: React.FC<Props> = ({ normalFlags, suspectedFlags, boardConfig }) => {
+export const GameInfoHeader: React.FC<Props> = ({ normalFlags, suspectedFlags, boardConfig }) => {
   const [showNormalFlag, setShowNormalFlag] = useState(true);
   return (
     <header className='flex justify-between items-center py-0.5'>

--- a/src/features/PlayGround/components/GameInfoHeader/index.tsx
+++ b/src/features/PlayGround/components/GameInfoHeader/index.tsx
@@ -13,7 +13,7 @@ type Props = {
 export const GameInfoHeader: React.FC<Props> = ({ normalFlags, suspectedFlags, boardConfig }) => {
   const [showNormalFlag, setShowNormalFlag] = useState(true);
   return (
-    <header className='flex justify-between items-center py-0.5'>
+    <header className='flex justify-between items-center'>
       <h1>Mine Sweeper</h1>
       <div className='flex gap-2' onClick={() => setShowNormalFlag(!showNormalFlag)}>
         {showNormalFlag ? (

--- a/src/features/PlayGround/components/GameToolBar/index.tsx
+++ b/src/features/PlayGround/components/GameToolBar/index.tsx
@@ -6,19 +6,21 @@ type Props = Pick<MineSweeper, 'init' | 'gameMode' | 'settings'>;
 
 export const GameToolBar: React.FC<Props> = ({ init, gameMode, settings }) => {
   return (
-    <select
-      className='bg-slate-500 p-1 rounded-none text-sm text-slate-100 focus:bg-slate-400 focus:scale-110 origin-left'
-      onChange={(e) => {
-        init(e.target.value as GameMode);
-      }}
-      defaultValue={gameMode}
-    >
-      {settings.gameModeList.map((mode) => (
-        <option key={mode} value={mode}>
-          {mode.charAt(0).toUpperCase() + mode.slice(1)}
-        </option>
-      ))}
-    </select>
+    <div className='felx justify-start'>
+      <select
+        className='bg-slate-500 p-1.5 rounded-none text-sm text-slate-100 focus:bg-slate-400 focus:scale-110 origin-left'
+        onChange={(e) => {
+          init(e.target.value as GameMode);
+        }}
+        defaultValue={gameMode}
+      >
+        {settings.gameModeList.map((mode) => (
+          <option key={mode} value={mode}>
+            {mode.charAt(0).toUpperCase() + mode.slice(1)}
+          </option>
+        ))}
+      </select>
+    </div>
   );
 };
 

--- a/src/features/PlayGround/components/GameToolBar/index.tsx
+++ b/src/features/PlayGround/components/GameToolBar/index.tsx
@@ -1,0 +1,25 @@
+'use client';
+
+import type { GameMode, MineSweeper } from '@/features/PlayGround/hooks/useMineSweeper';
+
+type Props = Pick<MineSweeper, 'init' | 'gameMode' | 'settings'>;
+
+export const GameToolBar: React.FC<Props> = ({ init, gameMode, settings }) => {
+  return (
+    <select
+      className='bg-slate-500 p-1 rounded-none text-sm text-slate-100 focus:bg-slate-400 focus:scale-110 origin-left'
+      onChange={(e) => {
+        init(e.target.value as GameMode);
+      }}
+      defaultValue={gameMode}
+    >
+      {settings.gameModeList.map((mode) => (
+        <option key={mode} value={mode}>
+          {mode.charAt(0).toUpperCase() + mode.slice(1)}
+        </option>
+      ))}
+    </select>
+  );
+};
+
+export default GameToolBar;

--- a/src/features/PlayGround/components/GameToolBar/index.tsx
+++ b/src/features/PlayGround/components/GameToolBar/index.tsx
@@ -6,7 +6,7 @@ type Props = Pick<MineSweeper, 'init' | 'gameMode' | 'settings'>;
 
 export const GameToolBar: React.FC<Props> = ({ init, gameMode, settings }) => {
   return (
-    <div className='felx justify-start'>
+    <nav className='felx justify-start'>
       <select
         className='bg-slate-500 p-1.5 rounded-none text-sm text-slate-100 focus:bg-slate-400 focus:scale-110 origin-left'
         onChange={(e) => {
@@ -20,7 +20,7 @@ export const GameToolBar: React.FC<Props> = ({ init, gameMode, settings }) => {
           </option>
         ))}
       </select>
-    </div>
+    </nav>
   );
 };
 

--- a/src/features/PlayGround/hooks/useMineSweeper.ts
+++ b/src/features/PlayGround/hooks/useMineSweeper.ts
@@ -157,3 +157,5 @@ const useMineSweeper = () => {
 };
 
 export default useMineSweeper;
+
+export type MineSweeper = ReturnType<typeof useMineSweeper>;

--- a/src/features/PlayGround/index.tsx
+++ b/src/features/PlayGround/index.tsx
@@ -1,11 +1,12 @@
 'use client';
 
 import { useEffect, useRef } from 'react';
-import Cell from './components/Cell';
 import useConfetti from '@/hooks/useConfetti';
-import useMineSweeper, { GameMode } from './hooks/useMineSweeper';
-import { Header } from './components/Header';
-import { toMarixPosition } from './functions/matrix';
+import useMineSweeper from './hooks/useMineSweeper';
+import { GameInfoHeader } from './components/GameInfoHeader';
+import Board from './components/Board';
+import GameToolBar from './components/GameToolBar';
+import GameContextAction from './components/GameContextAction';
 
 const PlayGround = () => {
   const {
@@ -55,7 +56,7 @@ const PlayGround = () => {
 
   return (
     <div>
-      <Header
+      <GameInfoHeader
         normalFlags={flags.normal}
         suspectedFlags={flags.suspected}
         boardConfig={board.meta}
@@ -66,53 +67,15 @@ const PlayGround = () => {
         }
         ref={boardRef}
       >
-        <div
-          className={'bg-slate-700 grid gap-1 p-2 w-fit'}
-          style={{
-            gridTemplateColumns: `repeat(${board.meta.cols}, 1fr)`,
-            gridTemplateRows: `repeat(${board.meta.rows}, 1fr)`,
-          }}
-        >
-          {board.data.flat().map((cell) => {
-            const [row, col] = toMarixPosition(cell.id, board.meta.cols);
-            return (
-              <Cell
-                key={cell.id}
-                cell={cell}
-                row={row}
-                col={col}
-                handleClick={open}
-                toggleFlag={toggleFlag}
-                switchFlagType={switchFlagType}
-              />
-            );
-          })}
-        </div>
+        <Board board={board} open={open} toggleFlag={toggleFlag} switchFlagType={switchFlagType} />
       </div>
       <div className='py-2'>
-        <select
-          className='bg-slate-500 p-1 rounded-none text-sm text-slate-100 focus:bg-slate-400 focus:scale-110 origin-left'
-          onChange={(e) => {
-            init(e.target.value as GameMode);
-          }}
-          defaultValue={gameMode}
-        >
-          {settings.gameModeList.map((mode) => (
-            <option key={mode} value={mode}>
-              {mode.charAt(0).toUpperCase() + mode.slice(1)}
-            </option>
-          ))}
-        </select>
+        <GameToolBar init={init} gameMode={gameMode} settings={settings} />
       </div>
 
       {(gameState === 'completed' || gameState === 'failed') && (
-        <div className='flex flex-col items-center py-10 gap-3'>
-          <button
-            className='bg-slate-500 shadow-[2px_2px_2px_#444,-1px_-1px_1px_#fff] text-white px-3 py-1 text-sm focus:bg-slate-400 focus:scale-110 origin-center'
-            onClick={restart}
-          >
-            NEW GAME
-          </button>
+        <div className='py-10'>
+          <GameContextAction restart={restart} />
         </div>
       )}
     </div>

--- a/src/features/PlayGround/index.tsx
+++ b/src/features/PlayGround/index.tsx
@@ -55,8 +55,8 @@ const PlayGround = () => {
   }, [gameMode]);
 
   return (
-    <div className='flex flex-col items-stretch'>
-      <div className='py-0.5'>
+    <div className='h-full pt-[7vh] flex flex-col items-stretch'>
+      <div className='py-0.5 flex flex-col justify-end'>
         <GameInfoHeader
           normalFlags={flags.normal}
           suspectedFlags={flags.suspected}
@@ -65,7 +65,7 @@ const PlayGround = () => {
       </div>
       <div
         className={
-          'overflow-auto w-fit h-fit max-w-[90vw] max-h-[55vh] md:max-h-[70vh] bg-black/50 dark:bg-white/50 select-none'
+          'overflow-auto max-w-[90vw] max-h-[55vh] md:max-h-[65vh] bg-black/50 dark:bg-white/50 select-none'
         }
         ref={boardRef}
       >
@@ -76,7 +76,7 @@ const PlayGround = () => {
       </div>
 
       {(gameState === 'completed' || gameState === 'failed') && (
-        <div className='py-10'>
+        <div className='py-5'>
           <GameContextAction restart={restart} />
         </div>
       )}

--- a/src/features/PlayGround/index.tsx
+++ b/src/features/PlayGround/index.tsx
@@ -55,7 +55,7 @@ const PlayGround = () => {
   }, [gameMode]);
 
   return (
-    <div className='h-full pt-[7vh] flex flex-col items-stretch'>
+    <div className='h-full pt-[10vh] flex flex-col items-stretch'>
       <div className='py-0.5 flex flex-col justify-end'>
         <GameInfoHeader
           normalFlags={flags.normal}
@@ -65,7 +65,7 @@ const PlayGround = () => {
       </div>
       <div
         className={
-          'overflow-auto max-w-[90vw] max-h-[55vh] md:max-h-[65vh] bg-black/50 dark:bg-white/50 select-none'
+          'overflow-auto max-w-[90vw] max-h-[55vh] md:max-h-[62vh] xl:max-h-[70vh] bg-black/50 dark:bg-white/50 select-none'
         }
         ref={boardRef}
       >

--- a/src/features/PlayGround/index.tsx
+++ b/src/features/PlayGround/index.tsx
@@ -55,12 +55,14 @@ const PlayGround = () => {
   }, [gameMode]);
 
   return (
-    <div>
-      <GameInfoHeader
-        normalFlags={flags.normal}
-        suspectedFlags={flags.suspected}
-        boardConfig={board.meta}
-      />
+    <div className='flex flex-col items-stretch'>
+      <div className='py-0.5'>
+        <GameInfoHeader
+          normalFlags={flags.normal}
+          suspectedFlags={flags.suspected}
+          boardConfig={board.meta}
+        />
+      </div>
       <div
         className={
           'overflow-auto w-fit h-fit max-w-[90vw] max-h-[55vh] md:max-h-[70vh] bg-black/50 dark:bg-white/50 select-none'


### PR DESCRIPTION
- [x] モバイルのsafariで検索バーを考慮した上で画面が丸ごとviewportに収まるようにする
- [x] 親コンポーネントでレイアウトを設定するようにする
  - 現在はレイアウト関連のスタイル定義が散乱しているので子コンポーネントからは取り除いて親コンポーネントにまとめる
- [x] タブレットでNEW GAMEボタンが画面外に出てしまう問題の解消