### PR TITLE
メインロジックを記述したカスタムフックをリファクタした

### DIFF
--- a/src/features/PlayGround/components/Cell/OpenedCell.tsx
+++ b/src/features/PlayGround/components/Cell/OpenedCell.tsx
@@ -49,7 +49,7 @@ const Count = ({ value }: { value: number }) => {
   );
 };
 
-const OpenedCell: React.FC<{ cell: CellData; isExploded: boolean }> = ({ cell }) => {
+const OpenedCell: React.FC<{ cell: CellData }> = ({ cell }) => {
   return (
     <div className={'h-full w-full bg-slate-50'}>
       {isMine(cell) ? (

--- a/src/features/PlayGround/components/Cell/index.tsx
+++ b/src/features/PlayGround/components/Cell/index.tsx
@@ -47,14 +47,7 @@ const getCell = (row: number, col: number): HTMLDivElement | null => {
   return document.querySelector(`div[data-row="${row}"][data-col="${col}"]`);
 };
 
-const Cell: React.FC<Props> = ({
-  cell,
-  row,
-  col,
-  handleClick,
-  toggleFlag,
-  switchFlagType,
-}) => {
+const Cell: React.FC<Props> = ({ cell, row, col, handleClick, toggleFlag, switchFlagType }) => {
   const cellRef = useRef<HTMLDivElement>(null);
 
   // TODO: 直線方向にボタンがないときに斜め方向も探索するようにする

--- a/src/features/PlayGround/components/Cell/index.tsx
+++ b/src/features/PlayGround/components/Cell/index.tsx
@@ -9,7 +9,6 @@ type Props = {
   cell: CellData;
   row: number;
   col: number;
-  isFailed: boolean;
   handleClick: (index: number) => void;
   toggleFlag: (index: number) => void;
   switchFlagType: (id: number) => void;
@@ -52,7 +51,6 @@ const Cell: React.FC<Props> = ({
   cell,
   row,
   col,
-  isFailed = false,
   handleClick,
   toggleFlag,
   switchFlagType,
@@ -95,7 +93,7 @@ const Cell: React.FC<Props> = ({
       onKeyDown={handleArrowMove}
     >
       {isOpened(cell) ? (
-        <OpenedCell cell={cell} isExploded={isFailed} />
+        <OpenedCell cell={cell} />
       ) : (
         <UnopenedCell
           cell={cell}

--- a/src/features/PlayGround/hooks/useMineSweeper.ts
+++ b/src/features/PlayGround/hooks/useMineSweeper.ts
@@ -113,7 +113,7 @@ const reducer = (state: State, action: Action): State => {
   }
 };
 
-const usePlayGround = () => {
+const useMineSweeper = () => {
   // reducer
   const [state, dispatch] = useReducer(reducer, initialize('easy'));
 
@@ -156,4 +156,4 @@ const usePlayGround = () => {
   };
 };
 
-export default usePlayGround;
+export default useMineSweeper;

--- a/src/features/PlayGround/hooks/usePlayGround.ts
+++ b/src/features/PlayGround/hooks/usePlayGround.ts
@@ -17,6 +17,7 @@ import {
 type GameState = 'initialized' | 'playing' | 'completed' | 'failed';
 
 export type GameMode = 'easy' | 'normal' | 'hard';
+const GAME_MODE_LIST: GameMode[] = ['easy', 'normal', 'hard'];
 
 const gameModeToOptions = (gameMode: GameMode): BoardConfig => {
   switch (gameMode) {
@@ -151,6 +152,7 @@ const usePlayGround = () => {
     toggleFlag,
     switchFlagType,
     flags: { normal: normalFlags, suspected: suspectedFlags },
+    settings: { gameModeList: GAME_MODE_LIST },
   };
 };
 

--- a/src/features/PlayGround/hooks/usePlayGround.ts
+++ b/src/features/PlayGround/hooks/usePlayGround.ts
@@ -37,7 +37,7 @@ type State = {
 
 type Action =
   | { type: 'init'; gameMode: GameMode }
-  | { type: 'reset' }
+  | { type: 'restart' }
   | { type: 'open'; index: number }
   | { type: 'toggleFlag'; index: number }
   | { type: 'switchFlagType'; index: number };
@@ -92,7 +92,7 @@ const reducer = (state: State, action: Action): State => {
     case 'init':
       return initialize(action.gameMode);
     // 同じゲームモードで初期化
-    case 'reset':
+    case 'restart':
       return initialize(state.gameMode);
     // マスを開く
     case 'open':
@@ -116,18 +116,42 @@ const usePlayGround = () => {
   // reducer
   const [state, dispatch] = useReducer(reducer, initialize('easy'));
 
+  // action
+  const init = useCallback(
+    (gameMode: GameMode) => dispatch({ type: 'init', gameMode }),
+    [dispatch],
+  );
+  const restart = useCallback(() => dispatch({ type: 'restart' }), [dispatch]);
+  const openAction = useCallback((index: number) => dispatch({ type: 'open', index }), [dispatch]);
+  const toggleFlag = useCallback(
+    (index: number) => dispatch({ type: 'toggleFlag', index }),
+    [dispatch],
+  );
+  const switchFlagType = useCallback(
+    (index: number) => dispatch({ type: 'switchFlagType', index }),
+    [dispatch],
+  );
+
   // middleware
   const [normalFlags, setNormalFlags] = useState(0);
   const [suspectedFlags, setSuspectedFlags] = useState(0);
   useEffect(() => {
     // クリアor失敗した場合にフラグの数が0になるが、終了時点でのフラグ数をキープしておくために終了時は更新しない
     if (state.gameState === 'completed' || state.gameState === 'failed') return;
-      
+
     setNormalFlags(countNormalFlags(state.board));
     setSuspectedFlags(countSuspectedFlags(state.board));
   }, [state]);
 
-  return { ...state, dispatch, flags: { normal: normalFlags, suspected: suspectedFlags } };
+  return {
+    ...state,
+    init,
+    restart,
+    open: openAction,
+    toggleFlag,
+    switchFlagType,
+    flags: { normal: normalFlags, suspected: suspectedFlags },
+  };
 };
 
 export default usePlayGround;

--- a/src/features/PlayGround/hooks/usePlayGround.ts
+++ b/src/features/PlayGround/hooks/usePlayGround.ts
@@ -1,4 +1,4 @@
-import { useReducer } from 'react';
+import { useCallback, useEffect, useReducer, useState } from 'react';
 import {
   Board,
   BoardConfig,
@@ -117,8 +117,15 @@ const usePlayGround = () => {
   const [state, dispatch] = useReducer(reducer, initialize('easy'));
 
   // middleware
-  const normalFlags = countNormalFlags(state.board);
-  const suspectedflags = countSuspectedFlags(state.board);
+  const [normalFlags, setNormalFlags] = useState(0);
+  const [suspectedflags, setSuspectedFlags] = useState(0);
+  useEffect(() => {
+    // クリアor失敗した場合にフラグの数が0になるが、終了時点でのフラグ数をキープしておくために終了時は更新しない
+    if (state.gameState === 'completed' || state.gameState === 'failed') return;
+      
+    setNormalFlags(countNormalFlags(state.board));
+    setSuspectedFlags(countSuspectedFlags(state.board));
+  }, [state]);
 
   return { ...state, dispatch, normalFlags, suspectedflags };
 };

--- a/src/features/PlayGround/hooks/usePlayGround.ts
+++ b/src/features/PlayGround/hooks/usePlayGround.ts
@@ -118,7 +118,7 @@ const usePlayGround = () => {
 
   // middleware
   const [normalFlags, setNormalFlags] = useState(0);
-  const [suspectedflags, setSuspectedFlags] = useState(0);
+  const [suspectedFlags, setSuspectedFlags] = useState(0);
   useEffect(() => {
     // クリアor失敗した場合にフラグの数が0になるが、終了時点でのフラグ数をキープしておくために終了時は更新しない
     if (state.gameState === 'completed' || state.gameState === 'failed') return;
@@ -127,7 +127,7 @@ const usePlayGround = () => {
     setSuspectedFlags(countSuspectedFlags(state.board));
   }, [state]);
 
-  return { ...state, dispatch, normalFlags, suspectedflags };
+  return { ...state, dispatch, flags: { normal: normalFlags, suspected: suspectedFlags } };
 };
 
 export default usePlayGround;

--- a/src/features/PlayGround/index.tsx
+++ b/src/features/PlayGround/index.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useCallback, useEffect, useRef } from 'react';
+import { useEffect, useRef } from 'react';
 import Cell from './components/Cell';
 import useConfetti from '@/hooks/useConfetti';
 import usePlayGround, { GameMode } from './hooks/usePlayGround';
@@ -8,7 +8,17 @@ import { Header } from './components/Header';
 import { toMarixPosition } from './functions/matrix';
 
 const PlayGround = () => {
-  const { board, gameState, gameMode, dispatch, flags } = usePlayGround();
+  const {
+    board,
+    gameState,
+    gameMode,
+    init,
+    restart,
+    open,
+    toggleFlag,
+    switchFlagType,
+    flags,
+  } = usePlayGround();
   const confetti = useConfetti();
   const boardRef = useRef<HTMLDivElement>(null);
 
@@ -42,19 +52,13 @@ const PlayGround = () => {
     }
   }, [gameMode]);
 
-  const handleClick = useCallback((index: number) => dispatch({ type: 'open', index }), [dispatch]);
-  const toggleFlag = useCallback(
-    (index: number) => dispatch({ type: 'toggleFlag', index }),
-    [dispatch],
-  );
-  const switchFlagType = useCallback(
-    (index: number) => dispatch({ type: 'switchFlagType', index }),
-    [dispatch],
-  );
-
   return (
     <div>
-      <Header normalFlags={flags.normal} suspectedFlags={flags.suspected} boardConfig={board.meta} />
+      <Header
+        normalFlags={flags.normal}
+        suspectedFlags={flags.suspected}
+        boardConfig={board.meta}
+      />
       <div
         className={
           'overflow-auto w-fit h-fit max-w-[90vw] max-h-[55vh] md:max-h-[70vh] bg-black/50 dark:bg-white/50 select-none'
@@ -77,7 +81,7 @@ const PlayGround = () => {
                 row={row}
                 col={col}
                 isFailed={gameState === 'failed'}
-                handleClick={handleClick}
+                handleClick={open}
                 toggleFlag={toggleFlag}
                 switchFlagType={switchFlagType}
               />
@@ -89,7 +93,7 @@ const PlayGround = () => {
         <select
           className='bg-slate-500 p-1 rounded-none text-sm text-slate-100 focus:bg-slate-400 focus:scale-110 origin-left'
           onChange={(e) => {
-            dispatch({ type: 'init', gameMode: e.target.value as GameMode });
+            init(e.target.value as GameMode);
           }}
         >
           <option defaultChecked={gameMode === 'easy'} value='easy'>
@@ -108,9 +112,7 @@ const PlayGround = () => {
         <div className='flex flex-col items-center py-10 gap-3'>
           <button
             className='bg-slate-500 shadow-[2px_2px_2px_#444,-1px_-1px_1px_#fff] text-white px-3 py-1 text-sm focus:bg-slate-400 focus:scale-110 origin-center'
-            onClick={() => {
-              dispatch({ type: 'reset' });
-            }}
+            onClick={restart}
           >
             NEW GAME
           </button>

--- a/src/features/PlayGround/index.tsx
+++ b/src/features/PlayGround/index.tsx
@@ -81,7 +81,6 @@ const PlayGround = () => {
                 cell={cell}
                 row={row}
                 col={col}
-                isFailed={gameState === 'failed'}
                 handleClick={open}
                 toggleFlag={toggleFlag}
                 switchFlagType={switchFlagType}

--- a/src/features/PlayGround/index.tsx
+++ b/src/features/PlayGround/index.tsx
@@ -8,7 +8,7 @@ import { Header } from './components/Header';
 import { toMarixPosition } from './functions/matrix';
 
 const PlayGround = () => {
-  const { board, gameState, gameMode, dispatch, normalFlags, suspectedflags } = usePlayGround();
+  const { board, gameState, gameMode, dispatch, flags } = usePlayGround();
   const confetti = useConfetti();
   const boardRef = useRef<HTMLDivElement>(null);
 
@@ -54,7 +54,7 @@ const PlayGround = () => {
 
   return (
     <div>
-      <Header normalFlags={normalFlags} suspectedFlags={suspectedflags} boardConfig={board.meta} />
+      <Header normalFlags={flags.normal} suspectedFlags={flags.suspected} boardConfig={board.meta} />
       <div
         className={
           'overflow-auto w-fit h-fit max-w-[90vw] max-h-[55vh] md:max-h-[70vh] bg-black/50 dark:bg-white/50 select-none'

--- a/src/features/PlayGround/index.tsx
+++ b/src/features/PlayGround/index.tsx
@@ -3,7 +3,7 @@
 import { useEffect, useRef } from 'react';
 import Cell from './components/Cell';
 import useConfetti from '@/hooks/useConfetti';
-import usePlayGround, { GameMode } from './hooks/usePlayGround';
+import useMineSweeper, { GameMode } from './hooks/useMineSweeper';
 import { Header } from './components/Header';
 import { toMarixPosition } from './functions/matrix';
 
@@ -19,7 +19,7 @@ const PlayGround = () => {
     switchFlagType,
     flags,
     settings,
-  } = usePlayGround();
+  } = useMineSweeper();
   const confetti = useConfetti();
   const boardRef = useRef<HTMLDivElement>(null);
 

--- a/src/features/PlayGround/index.tsx
+++ b/src/features/PlayGround/index.tsx
@@ -18,6 +18,7 @@ const PlayGround = () => {
     toggleFlag,
     switchFlagType,
     flags,
+    settings,
   } = usePlayGround();
   const confetti = useConfetti();
   const boardRef = useRef<HTMLDivElement>(null);
@@ -95,16 +96,13 @@ const PlayGround = () => {
           onChange={(e) => {
             init(e.target.value as GameMode);
           }}
+          defaultValue={gameMode}
         >
-          <option defaultChecked={gameMode === 'easy'} value='easy'>
-            Easy
-          </option>
-          <option defaultChecked={gameMode === 'normal'} value='normal'>
-            Normal
-          </option>
-          <option defaultChecked={gameMode === 'hard'} value='hard'>
-            Hard
-          </option>
+          {settings.gameModeList.map((mode) => (
+            <option key={mode} value={mode}>
+              {mode.charAt(0).toUpperCase() + mode.slice(1)}
+            </option>
+          ))}
         </select>
       </div>
 


### PR DESCRIPTION
- 名前を変更
  - `usePlayGround` => `useMineSweeper`
  - PlayGroundという名前は本質的ではなかったため
- 各アクションの関数を個別に公開するようにした
  - dispatchをラップする形で各関数を定義
  - 純粋関数であることを保ちつつuseCallbackで再定義を防ぐようにした
- その他
  - フラグ周りのインターフェースを微修正
  - ゲームクリア時にフラグがリセットされないようにした
    - メインのStateとは別の場所で状態を管理するようにした