### PR TITLE
各難易度に対応したURLにアクセスしてプレイできるようにした

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -3,7 +3,7 @@ import PlayGround from '@/features/PlayGround';
 export default function Home() {
   return (
     <main className='flex h-full w-full flex-col items-center'>
-      <PlayGround></PlayGround>
+      <PlayGround defaultGameMode={'easy'}></PlayGround>
     </main>
   );
 }

--- a/src/app/play/[gameMode]/page.tsx
+++ b/src/app/play/[gameMode]/page.tsx
@@ -3,6 +3,7 @@
 import PlayGround from '@/features/PlayGround';
 import { GAME_MODE_LIST, GameMode } from '@/features/PlayGround/hooks/useMineSweeper';
 import { useRouter } from 'next/navigation';
+import { useEffect } from 'react';
 
 type Props = {
   params: {
@@ -14,14 +15,19 @@ export default function Play({ params }: Props) {
   const router = useRouter();
   const { gameMode } = params;
 
-  // ゲームモードの文字列が不正な場合は404を返す
-  if (!GAME_MODE_LIST.includes(gameMode)) {
-    router.replace('/404');
-  }
+  const isValidGameMode = GAME_MODE_LIST.includes(gameMode);
+
+  useEffect(() => {
+    // ゲームモードの文字列が不正な場合は404を返す
+    if (!isValidGameMode) {
+      router.replace('/404');
+    }
+  }, [isValidGameMode, router]);
+
 
   return (
     <main className='flex h-full w-full flex-col items-center'>
-      <PlayGround defaultGameMode={gameMode}></PlayGround>
+      {isValidGameMode ? <PlayGround defaultGameMode={gameMode}></PlayGround> : null}
     </main>
   );
 }

--- a/src/app/play/[gameMode]/page.tsx
+++ b/src/app/play/[gameMode]/page.tsx
@@ -1,0 +1,27 @@
+'use client';
+
+import PlayGround from '@/features/PlayGround';
+import { GAME_MODE_LIST, GameMode } from '@/features/PlayGround/hooks/useMineSweeper';
+import { useRouter } from 'next/navigation';
+
+type Props = {
+  params: {
+    gameMode: GameMode;
+  };
+};
+
+export default function Play({ params }: Props) {
+  const router = useRouter();
+  const { gameMode } = params;
+
+  // ゲームモードの文字列が不正な場合は404を返す
+  if (!GAME_MODE_LIST.includes(gameMode)) {
+    router.replace('/404');
+  }
+
+  return (
+    <main className='flex h-full w-full flex-col items-center'>
+      <PlayGround defaultGameMode={gameMode}></PlayGround>
+    </main>
+  );
+}

--- a/src/features/PlayGround/components/GameToolBar/index.tsx
+++ b/src/features/PlayGround/components/GameToolBar/index.tsx
@@ -1,17 +1,27 @@
 'use client';
 
-import type { GameMode, MineSweeper } from '@/features/PlayGround/hooks/useMineSweeper';
+import {
+  GAME_MODE_LIST,
+  type GameMode,
+  type MineSweeper,
+} from '@/features/PlayGround/hooks/useMineSweeper';
+import { useRouter } from 'next/navigation';
 
-type Props = Pick<MineSweeper, 'init' | 'gameMode' | 'settings'>;
+type Props = Pick<MineSweeper, 'gameMode' | 'settings'>;
 
-export const GameToolBar: React.FC<Props> = ({ init, gameMode, settings }) => {
+export const GameToolBar: React.FC<Props> = ({ gameMode, settings }) => {
+  const router = useRouter();
+
+  const handleOnChange = (e: React.ChangeEvent<HTMLSelectElement>) => {
+    const gameMode = e.target.value as GameMode;
+    if (!GAME_MODE_LIST.includes(gameMode)) router.replace('/404');
+    router.push(`/play/${gameMode}`);
+  };
   return (
     <nav className='felx justify-start'>
       <select
         className='bg-slate-500 p-1.5 rounded-none text-sm text-slate-100 focus:bg-slate-400 focus:scale-110 origin-left'
-        onChange={(e) => {
-          init(e.target.value as GameMode);
-        }}
+        onChange={handleOnChange}
         defaultValue={gameMode}
       >
         {settings.gameModeList.map((mode) => (

--- a/src/features/PlayGround/hooks/useMineSweeper.ts
+++ b/src/features/PlayGround/hooks/useMineSweeper.ts
@@ -17,7 +17,7 @@ import {
 type GameState = 'initialized' | 'playing' | 'completed' | 'failed';
 
 export type GameMode = 'easy' | 'normal' | 'hard';
-const GAME_MODE_LIST: GameMode[] = ['easy', 'normal', 'hard'];
+export const GAME_MODE_LIST: GameMode[] = ['easy', 'normal', 'hard'];
 
 const gameModeToOptions = (gameMode: GameMode): BoardConfig => {
   switch (gameMode) {
@@ -113,9 +113,9 @@ const reducer = (state: State, action: Action): State => {
   }
 };
 
-const useMineSweeper = () => {
+const useMineSweeper = (defaultGameMode: GameMode = 'easy') => {
   // reducer
-  const [state, dispatch] = useReducer(reducer, initialize('easy'));
+  const [state, dispatch] = useReducer(reducer, initialize(defaultGameMode));
 
   // action
   const init = useCallback(

--- a/src/features/PlayGround/index.tsx
+++ b/src/features/PlayGround/index.tsx
@@ -13,18 +13,8 @@ type Props = {
 };
 
 const PlayGround: React.FC<Props> = ({ defaultGameMode }) => {
-  const {
-    board,
-    gameState,
-    gameMode,
-    init,
-    restart,
-    open,
-    toggleFlag,
-    switchFlagType,
-    flags,
-    settings,
-  } = useMineSweeper(defaultGameMode);
+  const { board, gameState, gameMode, restart, open, toggleFlag, switchFlagType, flags, settings } =
+    useMineSweeper(defaultGameMode);
   const confetti = useConfetti();
   const boardRef = useRef<HTMLDivElement>(null);
 
@@ -76,7 +66,7 @@ const PlayGround: React.FC<Props> = ({ defaultGameMode }) => {
         <Board board={board} open={open} toggleFlag={toggleFlag} switchFlagType={switchFlagType} />
       </div>
       <div className='py-2'>
-        <GameToolBar init={init} gameMode={gameMode} settings={settings} />
+        <GameToolBar gameMode={gameMode} settings={settings} />
       </div>
 
       {(gameState === 'completed' || gameState === 'failed') && (

--- a/src/features/PlayGround/index.tsx
+++ b/src/features/PlayGround/index.tsx
@@ -2,13 +2,17 @@
 
 import { useEffect, useRef } from 'react';
 import useConfetti from '@/hooks/useConfetti';
-import useMineSweeper from './hooks/useMineSweeper';
+import useMineSweeper, { GameMode } from './hooks/useMineSweeper';
 import { GameInfoHeader } from './components/GameInfoHeader';
 import Board from './components/Board';
 import GameToolBar from './components/GameToolBar';
 import GameContextAction from './components/GameContextAction';
 
-const PlayGround = () => {
+type Props = {
+  defaultGameMode: GameMode;
+};
+
+const PlayGround: React.FC<Props> = ({ defaultGameMode }) => {
   const {
     board,
     gameState,
@@ -20,7 +24,7 @@ const PlayGround = () => {
     switchFlagType,
     flags,
     settings,
-  } = useMineSweeper();
+  } = useMineSweeper(defaultGameMode);
   const confetti = useConfetti();
   const boardRef = useRef<HTMLDivElement>(null);
 


### PR DESCRIPTION
- PlayGroundの引数で難易度を指定できるようにした
- 難易度セレクタで難易度変更したときの挙動を初期化ではなくページ遷移に変更

やらなかったこと
- 難易度セレクタをnext/linkに置き換える(SEO向上)