### PR TITLE
画面全体にselect-noneを適用して不必要なメニューが表示されないようにした

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -2,7 +2,7 @@ import PlayGround from '@/features/PlayGround';
 
 export default function Home() {
   return (
-    <main className='flex h-full w-full flex-col items-center'>
+    <main className='flex h-full w-full flex-col items-center select-none'>
       <PlayGround></PlayGround>
     </main>
   );

--- a/src/features/PlayGround/index.tsx
+++ b/src/features/PlayGround/index.tsx
@@ -65,7 +65,7 @@ const PlayGround = () => {
       </div>
       <div
         className={
-          'overflow-auto max-w-[90vw] max-h-[55vh] md:max-h-[62vh] xl:max-h-[70vh] bg-black/50 dark:bg-white/50 select-none'
+          'overflow-auto max-w-[90vw] max-h-[55vh] md:max-h-[62vh] xl:max-h-[70vh] bg-black/50 dark:bg-white/50'
         }
         ref={boardRef}
       >


### PR DESCRIPTION
- 主にiPadにおいて長押しをした際に難易度セレクタの文字にコンテキストメニューが表示されてしまうことがあった
- 盤面ではなく、画面全体を覆っているmainタグに`select-none`を適用することで改善を図る